### PR TITLE
Rollback .gitattributes change from last PR 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.wasm filter=lfs diff=lfs merge=lfs -text
-*.zip filter=lfs diff=lfs merge=lfs -binary
+*.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
I got a report that keeps failing randomly in different OS, there is something weird on `.yarn/cache` folder. 

**NOTE:** For those than installing go error probably the best will be to run `yarn cache clean --all`